### PR TITLE
vibe.data.serialization: Also respect policy attributes on types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 .dub
 .vs
 libvibe_core.a
-vibe-core-test-*
+vibe-serialization-test-*
 *.exe
 *.lst
 *.obj

--- a/source/vibe/data/serialization.d
+++ b/source/vibe/data/serialization.d
@@ -374,7 +374,7 @@ private template serializeValueImpl(Serializer, alias Policy) {
 
 		alias TU = Unqual!T;
 
-		alias ATTRIBUTES = AliasSeq!(FIELD_ATTRIBUTES, __traits(getAttributes, T));
+		alias ATTRIBUTES = AliasSeq!(FIELD_ATTRIBUTES, TypeAttributes!T);
 
 		alias Traits = .Traits!(TU, _Policy, ATTRIBUTES);
 
@@ -719,7 +719,7 @@ private template deserializeValueImpl(Serializer, alias Policy) {
 	{
 		import std.typecons : BitFlags, Nullable, Typedef, TypedefType, Tuple;
 
-		alias ATTRIBUTES = AliasSeq!(FIELD_ATTRIBUTES, __traits(getAttributes, T));
+		alias ATTRIBUTES = AliasSeq!(FIELD_ATTRIBUTES, TypeAttributes!T);
 
 		alias Traits = .Traits!(T, _Policy, ATTRIBUTES);
 
@@ -1479,6 +1479,13 @@ unittest {
 private template hasPolicyAttributeL(alias T, alias POLICY, ATTRIBUTES...)
 {
 	enum hasPolicyAttributeL = hasAttributeL!(T!POLICY, ATTRIBUTES) || hasAttributeL!(T!DefaultPolicy, ATTRIBUTES);
+}
+
+private template TypeAttributes(T) {
+	static if (__traits(compiles, __traits(identifier, T)))
+		alias TypeAttributes = AliasSeq!(__traits(getAttributes, T));
+	else  // D < 2.101.0 raises an error when attempting to get attributes of built-in types.
+		alias TypeAttributes = AliasSeq!();
 }
 
 private static auto getPolicyAttribute(string field, alias Attribute, alias Policy, Attributes...)(Attribute!DefaultPolicy default_value)

--- a/source/vibe/data/serialization.d
+++ b/source/vibe/data/serialization.d
@@ -1477,13 +1477,6 @@ private template hasPolicyAttributeL(alias T, alias POLICY, ATTRIBUTES...)
 	enum hasPolicyAttributeL = hasAttributeL!(T!POLICY, ATTRIBUTES) || hasAttributeL!(T!DefaultPolicy, ATTRIBUTES);
 }
 
-private static T getAttribute(TT, string mname, T)(T default_value)
-{
-	enum val = findFirstUDA!(T, __traits(getMember, TT, mname));
-	static if (val.found) return val.value;
-	else return default_value;
-}
-
 private static auto getPolicyAttribute(string field, alias Attribute, alias Policy, Attributes...)(Attribute!DefaultPolicy default_value)
 {
 	enum match(alias A) = matchesUDAKind!(A, Attribute!Policy);


### PR DESCRIPTION
It is not always possible to specify policy attributes on fields, as
we may want to control serialization/deserialization of values
elsewhere than fields. Since there's no way to specify policy
attributes via wrappers such as deserializeJson, allow specifying them
on the type as well.

Fixes https://github.com/vibe-d/vibe.d/issues/2820