### PR TITLE
Improve symbol equality test

### DIFF
--- a/source/vibe/data/serialization.d
+++ b/source/vibe/data/serialization.d
@@ -1428,7 +1428,7 @@ private template hasPolicyAttribute(alias T, alias POLICY, alias decl)
 {
 	// __traits(identifier) to hack around T being a template and not a type
 	// this if makes hasPolicyAttribute!(OptionalAttribute) == true when EmbedNullableIgnoreNullAttribute is present.
-	static if (__traits(identifier, T) == __traits(identifier, OptionalAttribute))
+	static if (__traits(isSame, OptionalAttribute, T))
 		enum hasPolicyAttribute = hasPolicyAttributeImpl!(T, POLICY, decl)
 			|| hasPolicyAttributeImpl!(EmbedNullableIgnoreNullAttribute, POLICY, decl);
 	else


### PR DESCRIPTION
Avoids the rather costly string comparison and uses a proper identity check instead of just comparing the symbol name.